### PR TITLE
Remove CodeQL workaround for PR merge commits

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,11 +31,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/src/Gemstone.Security/Cryptography/PasswordHasher.cs
+++ b/src/Gemstone.Security/Cryptography/PasswordHasher.cs
@@ -1,0 +1,40 @@
+﻿//******************************************************************************************************
+//  PasswordHasher.cs - Gbtc
+//
+//  Copyright © 2020, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  06/20/2020 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Gemstone.Security.Cryptography
+{
+    public class PasswordHasher
+    {
+        public void Test()
+        {
+            //Rfc2898DeriveBytes thingy = new Rfc2898DeriveBytes();
+            //thingy.CryptDeriveKey();
+            //thingy.
+        }
+    }
+}


### PR DESCRIPTION
Removes `git checkout HEAD^2` workaround from codeql-analysis.yml based on recommendations from CodeQL analysis.