### PR TITLE
Update Microsoft.AspNetCore.Authentication.Negotiate to 9.0.4

### DIFF
--- a/src/Gemstone.Security/Gemstone.Security.csproj
+++ b/src/Gemstone.Security/Gemstone.Security.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="9.0.4" />
     <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
 
     <ProjectReference Include="..\..\..\common\src\Gemstone\Gemstone.Common.csproj" Condition="'$(Configuration)'=='Development'" />


### PR DESCRIPTION
Bump Microsoft.AspNetCore.Authentication.Negotiate package from v8.x to 9.0.4, since this project targets .NET 9.

This also makes the package version match other Gemstone libraries, such as Gemstone.Web:
https://github.com/gemstone/web/blob/master/src/Gemstone.Web/Gemstone.Web.csproj

